### PR TITLE
[breaking] VFS name now must be passed in as a CString

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes will be documented in this file.
 
+## 0.3.0 - 2025-05-26
+
+- `register_dynamic` and `register_static` now require the VFS name to be passed in as a CString.
+
 ## 0.2.0 - 2025-05-19
 
 - `PragmaErr` now requires an explicit error code and external construction.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -312,7 +312,7 @@ checksum = "8917285742e9f3e1683f0a9c4e6b57960b7314d0b08d30d1ecd426713ee2eee9"
 
 [[package]]
 name = "sqlite-plugin"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "bindgen",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sqlite-plugin"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2024"
 authors = ["orbitinghail <hello@orbitinghail.dev>"]
 license = "MIT OR Apache-2.0"

--- a/examples/memvfs.rs
+++ b/examples/memvfs.rs
@@ -1,6 +1,10 @@
 // cargo build --example memvfs --features dynamic
 
-use std::{ffi::c_void, os::raw::c_char, sync::Arc};
+use std::{
+    ffi::{CStr, c_void},
+    os::raw::c_char,
+    sync::Arc,
+};
 
 use parking_lot::Mutex;
 use sqlite_plugin::{
@@ -223,9 +227,15 @@ pub unsafe extern "C" fn sqlite3_memvfs_init(
     p_api: *mut sqlite3_api_routines,
 ) -> std::os::raw::c_int {
     let vfs = MemVfs { files: Default::default() };
-    if let Err(err) =
-        unsafe { register_dynamic(p_api, "mem", vfs, RegisterOpts { make_default: true }) }
-    {
+    const MEMVFS_NAME: &CStr = c"mem";
+    if let Err(err) = unsafe {
+        register_dynamic(
+            p_api,
+            MEMVFS_NAME.to_owned(),
+            vfs,
+            RegisterOpts { make_default: true },
+        )
+    } {
         return err;
     }
 


### PR DESCRIPTION
`register_dynamic` and `register_static` now require the VFS name to be passed in as a CString.