### PR TITLE
handle panics

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -37,15 +37,23 @@ jobs:
         run: curl -LsSf https://get.nexte.st/latest/linux | tar zxf - -C /usr/local/bin
 
       - name: Build
-        run: cargo build --all-features
+        run: |
+          cargo build --no-default-features --features static
+          cargo build --no-default-features --features static,std
+          cargo build --no-default-features --features dynamic
+          cargo build --no-default-features --features dynamic,std
 
       - name: Test
-        run: cargo nextest run --all-features
+        run: |
+          cargo nextest run --no-default-features --features static,dynamic
+          cargo nextest run --no-default-features --features static,dynamic,std
 
       - name: Test memvfs
         run: |
-          cargo build --example memvfs --features dynamic
+          cargo build --example memvfs --features dynamic,std
           cat examples/test_memvfs.sql | sqlite3
+          cat examples/test_memvfs_panic.sql | sqlite3 >/tmp/memvfs_panic 2>&1 \
+            || grep -q "unknown error (2)" /tmp/memvfs_panic
 
       - name: Clippy
         uses: auguwu/clippy-action@94a9ff2f6920180b89e5c03d121d0af04a9d3e03 # 1.4.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,8 +29,9 @@ bindgen = { version = "0.72", default-features = false }
 default = ["static"]
 static = []
 dynamic = []
+std = []
 
 [[example]]
 name = "memvfs"
 crate-type = ["cdylib"]
-required-features = ["dynamic"]
+required-features = ["dynamic", "std"]

--- a/examples/memvfs.rs
+++ b/examples/memvfs.rs
@@ -1,4 +1,4 @@
-// cargo build --example memvfs --features dynamic
+// cargo build --example memvfs --features dynamic,std
 
 use std::{ffi::c_void, os::raw::c_char, sync::Arc};
 
@@ -181,7 +181,11 @@ impl Vfs for MemVfs {
         pragma: Pragma<'_>,
     ) -> Result<Option<String>, PragmaErr> {
         log::debug!("pragma: file={:?}, pragma={:?}", handle.name, pragma);
-        Err(PragmaErr::NotFound)
+        if pragma.name == "memvfs_panic" {
+            panic!("testing panic")
+        } else {
+            Err(PragmaErr::NotFound)
+        }
     }
 }
 

--- a/examples/test_memvfs_panic.sql
+++ b/examples/test_memvfs_panic.sql
@@ -13,16 +13,8 @@
 .databases
 .vfsinfo
 
+-- ensure that panics are handled
+pragma memvfs_panic;
+
+-- but they cause all future calls to also fail!
 CREATE TABLE t1(a, b);
-INSERT INTO t1 VALUES(1, 2);
-INSERT INTO t1 VALUES(3, 4);
-SELECT * FROM t1;
-pragma hello_vfs=1234;
-
-select * from dbstat;
-
-vacuum;
-drop table t1;
-vacuum;
-
-select * from dbstat;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-#![no_std]
+#![cfg_attr(not(feature = "std"), no_std)]
 extern crate alloc;
 
 pub mod vars {


### PR DESCRIPTION
If the VFS panics, we need to ensure we stop unwinding the panic at the FFI boundary to SQLite. This adds some perf overhead, so I only enable it if you want to pull in `std`.