### PR TITLE
Correctly set pMethods in x_open

### DIFF
--- a/src/vfs.rs
+++ b/src/vfs.rs
@@ -421,6 +421,15 @@ unsafe extern "C" fn x_open<T: Vfs>(
     flags: c_int,
     p_out_flags: *mut c_int,
 ) -> c_int {
+    // From https://sqlite.org/c3ref/vfs.html:
+    // "Note that the xOpen method must set the sqlite3_file.pMethods to either a valid
+    // sqlite3_io_methods object or to NULL. xOpen must do this even if the open fails."
+    unsafe {
+        if let Some(f) = p_file.as_mut() {
+            f.pMethods = core::ptr::null();
+        }
+    }
+
     fallible(|| {
         let opts = flags.into();
         let name = unsafe { lossy_cstr(z_name) }.ok();

--- a/src/vfs.rs
+++ b/src/vfs.rs
@@ -424,10 +424,8 @@ unsafe extern "C" fn x_open<T: Vfs>(
     // From https://sqlite.org/c3ref/vfs.html:
     // "Note that the xOpen method must set the sqlite3_file.pMethods to either a valid
     // sqlite3_io_methods object or to NULL. xOpen must do this even if the open fails."
-    unsafe {
-        if let Some(f) = p_file.as_mut() {
-            f.pMethods = core::ptr::null();
-        }
+    if let Some(f) = unsafe { p_file.as_mut() } {
+        f.pMethods = core::ptr::null();
     }
 
     fallible(|| {


### PR DESCRIPTION
Previously `pMethods` contained undefined data if `x_open` failed before setting it.

See this excerpt from https://sqlite.org/c3ref/vfs.html:
> Note that the xOpen method must set the sqlite3_file.pMethods to either a valid [sqlite3_io_methods](https://sqlite.org/c3ref/io_methods.html) object or to NULL. xOpen must do this even if the open fails.

Feel free to edit the comment if you don't want the spec quote in there. :)