### PR TITLE
Reduce minimum sqlite version to 3.37.2

### DIFF
--- a/src/vfs.rs
+++ b/src/vfs.rs
@@ -16,7 +16,7 @@ use core::{
 
 /// The minimim supported `SQLite` version.
 // If you need to make this earlier, make sure the tests are testing the earlier version
-pub const MIN_SQLITE_VERSION_NUMBER: i32 = 3043000;
+pub const MIN_SQLITE_VERSION_NUMBER: i32 = 3037002;
 
 const DEFAULT_MAX_PATH_LEN: i32 = 512;
 pub const DEFAULT_SECTOR_SIZE: i32 = 4096;


### PR DESCRIPTION
This ships on Ubuntu 22.04, which is still an important build target for ABI compatibility with older glibc.

I ran sqlite-plugins unit tests and my own regression suite in an Ubuntu 22.04 container and everything seemed fine.